### PR TITLE
Only print warning when using old cothread version

### DIFF
--- a/src/python/epicscorelibs/path/cothread.py
+++ b/src/python/epicscorelibs/path/cothread.py
@@ -14,23 +14,18 @@ import os, sys, warnings
 
 from . import get_lib
 
-if "cothread" in sys.modules:
-    # Ensure we don't `import cothread` ourselves as that can have side-effects
-    cothread = sys.modules["cothread"]
-    if hasattr(cothread, "_version"):
-        # This attribute only exists in cothread 2.19+.
-        # It is always safe to use alongside epicscorelibs
-        pass
-    else:
-        # Some cothread versions only include major and minor, no build version
-        version_components = cothread.__version__.split(".")
-        major = int(version_components[0])
-        minor = int(version_components[1])
-        if major >= 2 and minor >=16:
-            # Cothread 2.16 was the first to fallback to epicscorelibs' get_lib functionality
-            pass
-        else:
-            warnings.warn("epicscorelibs.path.cothread must be imported before cothread.catools to have effect")
+def check_cothread_order():
+    if "cothread" not in sys.modules:
+        return
+    cothread = sys.modules.get("cothread")
+    # >= 2.16 will attempt to import this module
+    ver = tuple(int(c) for c in cothread.__version__.split("."))
+    if ver < (2, 16):
+        warnings.warn("epicscorelibs.path.cothread must be imported before cothread.catools to have effect")
+
+
+check_cothread_order()
+del check_cothread_order
 
 # don't override if already set
 if 'CATOOLS_LIBCA_PATH' not in os.environ:

--- a/src/python/epicscorelibs/path/cothread.py
+++ b/src/python/epicscorelibs/path/cothread.py
@@ -14,8 +14,23 @@ import os, sys, warnings
 
 from . import get_lib
 
-if 'cothread.load_ca' in sys.modules or 'cothread.catools' in sys.modules:
-    warnings.warn("epicscorelibs.path.cothread must be imported before cothread.catools to have effect")
+if "cothread" in sys.modules:
+    # Ensure we don't `import cothread` ourselves as that can have side-effects
+    cothread = sys.modules["cothread"]
+    if hasattr(cothread, "_version"):
+        # This attribute only exists in cothread 2.19+.
+        # It is always safe to use alongside epicscorelibs
+        pass
+    else:
+        # Some cothread versions only include major and minor, no build version
+        version_components = cothread.__version__.split(".")
+        major = int(version_components[0])
+        minor = int(version_components[1])
+        if major >= 2 and minor >=16:
+            # Cothread 2.16 was the first to fallback to epicscorelibs' get_lib functionality
+            pass
+        else:
+            warnings.warn("epicscorelibs.path.cothread must be imported before cothread.catools to have effect")
 
 # don't override if already set
 if 'CATOOLS_LIBCA_PATH' not in os.environ:


### PR DESCRIPTION
Everything from cothread 2.16+ is safe to use alongside epicscorelibs.

This has been manually tested with Python 2.7 with cothread 2.13.1 through 2.18.1, and Python 3.8 with cothread 2.16 through 2.19.1. 

Fixes #22 

CC @Araneidae 