### PR TITLE
Add Python 3.12 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,11 @@ jobs:
             pyver: cp311-cp311
             piparch: manylinux2014_x86_64
 
+          - name: linux 3.12 amd64
+            os: ubuntu-latest
+            pyver: cp312-cp312
+            piparch: manylinux2014_x86_64
+
           # Linux py builds x64
           - name: linux 2.7 i686
             os: ubuntu-latest
@@ -113,34 +118,39 @@ jobs:
 
           # OSX py builds
           - name: osx 3.6 intel
-            os: macos-latest
+            os: macos-13
             python: "3.6"
             piparch: macosx_10_9_intel
 
           - name: osx 3.7 intel
-            os: macos-latest
+            os: macos-13
             python: "3.7"
             piparch: macosx_10_9_intel
 
-          - name: osx 3.8 intel
+          - name: osx 3.8 arm64
             os: macos-latest
             python: "3.8"
-            piparch: macosx_10_9_intel
+            piparch: macosx_11_0_arm64
 
-          - name: osx 3.9 intel
+          - name: osx 3.9 arm64
             os: macos-latest
             python: "3.9"
-            piparch: macosx_10_9_intel
+            piparch: macosx_11_0_arm64
 
-          - name: osx 3.10 intel
+          - name: osx 3.10 arm64
             os: macos-latest
             python: "3.10"
-            piparch: macosx_10_10_intel
+            piparch: macosx_11_0_arm64
 
-          - name: osx 3.11 intel
+          - name: osx 3.11 arm64
             os: macos-latest
             python: "3.11"
-            piparch: macosx_10_10_intel
+            piparch: macosx_11_0_arm64
+
+          - name: osx 3.12 arm64
+            os: macos-latest
+            python: "3.12"
+            piparch: macosx_11_0_arm64
 
           # Windows py builds
 
@@ -184,13 +194,18 @@ jobs:
             python: "3.11"
             piparch: win_amd64
 
+          - name: win64 3.12
+            os: windows-latest
+            python: "3.12"
+            piparch: win_amd64
+
     steps:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
 
       - name: Setup native python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python || '3.7' }}
           #architecture: x64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -210,6 +210,12 @@ jobs:
           python-version: ${{ matrix.python || '3.7' }}
           #architecture: x64
 
+      # TLS 1.0 and 1.1 support was removed from pypi so the cached pip won't work
+      - name: Python 3.5 Fix
+        if: ${{ matrix.python == '3.5' }}
+        run: |
+          curl https://bootstrap.pypa.io/pip/3.5/get-pip.py | python
+
       - name: Native Prep/Info
         run: |
           python -m pip install --upgrade pip

--- a/setup.py
+++ b/setup.py
@@ -559,7 +559,7 @@ for use by python modules.  Either dynamically with ctypes or statically by comp
     python_requires='>=2.7',
     install_requires=[
         'setuptools', # needed at runtime for 'pkg_resources'
-        'setuptools_dso>=2.9a1', # 'setuptools_dso.runtime' used in 'epicscorelibs.path'
+        'setuptools-dso>=2.11a2', # 'setuptools_dso.runtime' used in 'epicscorelibs.path'
         'numpy', # needed for epicscorelibs.ca.dbr
     ],
 


### PR DESCRIPTION
This bumps `setuptools-dso` to the newest alpha release of 2.11a2 which includes Python 3.12 support