### PR TITLE
Fix CI (checkout and upload-artfact)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -292,7 +292,7 @@ jobs:
       - name: Save Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: epicscorelibs
+          name: epicscorelibs-${{ matrix.python || matrix.pyver }}-${{ matrix.piparch || 'source' }}
           path: dist/*
 
       - name: Upload wheels

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -200,7 +200,7 @@ jobs:
             piparch: win_amd64
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -290,7 +290,7 @@ jobs:
         run: ls dist/*
 
       - name: Save Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: epicscorelibs
           path: dist/*


### PR DESCRIPTION
Bump checkout and upload-artifact to v4. See:
https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/