### PR TITLE
Fix cothread version parsing to handle suffixes

### DIFF
--- a/src/python/epicscorelibs/path/cothread.py
+++ b/src/python/epicscorelibs/path/cothread.py
@@ -18,8 +18,16 @@ def check_cothread_order():
     if "cothread" not in sys.modules:
         return
     cothread = sys.modules.get("cothread")
+
+    ver = ()
+    for c in cothread.__version__.split("."):
+        try:
+            ver = ver + (int(c), )
+        except ValueError:
+            # Ignore setuptools_scm auto-generated trailing parts of a version number e.g. "2.20.1.dev1+g82e2778.d20241105"
+            pass
+
     # >= 2.16 will attempt to import this module
-    ver = tuple(int(c) for c in cothread.__version__.split("."))
     if ver < (2, 16):
         warnings.warn("epicscorelibs.path.cothread must be imported before cothread.catools to have effect")
 

--- a/src/python/epicscorelibs/path/cothread.py
+++ b/src/python/epicscorelibs/path/cothread.py
@@ -19,13 +19,11 @@ def check_cothread_order():
         return
     cothread = sys.modules.get("cothread")
 
-    ver = ()
-    for c in cothread.__version__.split("."):
-        try:
-            ver = ver + (int(c), )
-        except ValueError:
-            # Ignore setuptools_scm auto-generated trailing parts of a version number e.g. "2.20.1.dev1+g82e2778.d20241105"
-            pass
+    # Slice to first two elements to avoid attempting to parse certain types
+    # of auto-generated version numbers that are generated from setuptools_scm
+    # inside of cothread. e.g. trying to install directly from Github yields a
+    # version like "2.20.1.dev1+g82e2778.d20241105".
+    ver = tuple(int(c) for c in cothread.__version__.split(".")[:2])
 
     # >= 2.16 will attempt to import this module
     if ver < (2, 16):


### PR DESCRIPTION
These suffixes are auto-generated from setuptools_scm, and are not usually just integers. For example `2.20.1.dev1+g82e2778.d20241105` is a valid version for Cothread. Such a version number is generated if you install from a Git checkout - see [docs for details](https://setuptools-scm.readthedocs.io/en/latest/usage/#default-versioning-scheme)

This came up when attempting to create a pythonSoftIOC CI run that installed all of its dependencies directly from GitHub master branches - see [this PR](https://github.com/DiamondLightSource/pythonSoftIOC/pull/174)