### PR TITLE
Disable win64 build for py3.5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -169,10 +169,11 @@ jobs:
           #  python: "2.7"
           #  piparch: win_amd64
 
-          - name: win64 3.5
-            os: windows-2019
-            python: "3.5"
-            piparch: win_amd64
+          ## missing Microsoft Visual C++ 14.0
+          # - name: win64 3.5
+          #   os: windows-latest
+          #   python: "3.5"
+          #   piparch: win_amd64
 
           - name: win64 3.6
             os: windows-latest


### PR DESCRIPTION
GHA will shortly remove the `windows-2019` image, and the `windows-2022` image lacks VS 14.0.  So it will no longer be possible to build wheels for win64 + py3.5.