### PR TITLE
Remove epicscorelibs.path dependency on compiler

### DIFF
--- a/src/python/epicscorelibs/ca/cadef.py
+++ b/src/python/epicscorelibs/ca/cadef.py
@@ -17,12 +17,13 @@ __all__ = [
 
 
 import ctypes
+import platform
 
 from epicscorelibs import path
 
 from . import py23
 
-if path.OS_CLASS == "WIN32":
+if platform.system() == "Windows":
     # On windows, use stdcall calling convention for libca
     libca = ctypes.WinDLL(path.get_lib("ca"), ctypes.RTLD_GLOBAL)
 else:

--- a/src/python/epicscorelibs/ioc.py
+++ b/src/python/epicscorelibs/ioc.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 import ctypes
 import code
 import argparse
+import platform
 import sys
 import os
 import atexit
@@ -15,7 +16,7 @@ from . import path
 
 
 # The libraries we need to run up a soft IOC, don't load dbCore twice
-if path.OS_CLASS == "WIN32":
+if platform.system() == "Windows":
     Com = ctypes.WinDLL(path.get_lib("Com"), mode=ctypes.RTLD_GLOBAL)
 else:
     Com = ctypes.CDLL(path.get_lib("Com"), mode=ctypes.RTLD_GLOBAL)

--- a/src/python/epicscorelibs/path/__init__.py
+++ b/src/python/epicscorelibs/path/__init__.py
@@ -1,8 +1,6 @@
 
 import os
-from glob import glob
 
-from ..config import get_config_var
 from setuptools_dso.runtime import dylink_prepare_dso, find_dso
 
 __all__ = (
@@ -12,17 +10,6 @@ __all__ = (
 )
 
 base_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-
-
-# parts of library file names
-OS_CLASS = get_config_var("OS_CLASS")
-if OS_CLASS=='WIN32':
-    _prefix, _suffix = '', '.dll'
-elif OS_CLASS=='Darwin':
-    _prefix, _suffix = 'lib', '.dylib'
-else:
-    _prefix, _suffix = 'lib', '.so'
-
 include_path = os.path.join(base_path, 'include')
 lib_path = os.path.join(base_path, 'lib')
 

--- a/src/python/epicscorelibs/test/test_load.py
+++ b/src/python/epicscorelibs/test/test_load.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 
 import os
 import ctypes
+import platform
 
 from .. import path
 
@@ -14,7 +15,7 @@ def test_loading():
 
     ca = ctypes.CDLL(path.get_lib('ca'), mode=ctypes.RTLD_GLOBAL)
 
-    if path.OS_CLASS=='WIN32':
+    if platform.system() == "Windows":
         # Base libs contain functions using a mixture of cdecl and stdcall calling conventions
         # make WinDLL w/o actually loading again
         ca_s = ctypes.WinDLL(ca._name, handle=ca._handle)


### PR DESCRIPTION
Before this commit, an import of `epicscorelibs.path` would compute some variables, including about the compiler, to determine the `OS_CLASS`. However this was unused except in tests. This commit removes `epicscorelibs.path.OS_CLASS` and replaces references to it with `platform.system()` instead.

Fixes #42, fixes #41